### PR TITLE
Fix __delitem__ to remove reference from given key

### DIFF
--- a/multi_key_dict.py
+++ b/multi_key_dict.py
@@ -151,6 +151,10 @@ class multi_key_dict(object):
                 key_type = str(type(k))
                 if (key_type in self.__dict__ and k in self.__dict__[key_type]):
                     del self.__dict__[key_type][k]
+					
+			# remove the reference from the given key
+            del self.__dict__[key_type][key]
+			
         else:
             raise KeyError(key)
 

--- a/multi_key_dict.py
+++ b/multi_key_dict.py
@@ -151,10 +151,10 @@ class multi_key_dict(object):
                 key_type = str(type(k))
                 if (key_type in self.__dict__ and k in self.__dict__[key_type]):
                     del self.__dict__[key_type][k]
-					
-			# remove the reference from the given key
+
+            # remove the reference from the given key
             del self.__dict__[key_type][key]
-			
+
         else:
             raise KeyError(key)
 

--- a/multi_key_dict.py
+++ b/multi_key_dict.py
@@ -482,6 +482,7 @@ def test_multi_key_dict():
     curr_len = len(m)
     del m[12]
     assert( len(m) == curr_len - 1 ), 'expected len(m) == %d' % (curr_len - 1)
+    assert(not m.has_key(12)), 'expected deleted key to no longer be found!'
 
     # try again 
     try:


### PR DESCRIPTION
Previously, the __delitem__ method deleted the value and references from
other keys, but did not remove the reference from the given key. This
would cause the has_key method to incorrectly indicate that the key was
present - even after it had been deleted.